### PR TITLE
Fix build errors and failure to terminate

### DIFF
--- a/RFReceiver.cpp
+++ b/RFReceiver.cpp
@@ -148,6 +148,7 @@ void RFReceiver::processCtrlBreak(int signum, void *userdata) {
   //receiver->stop();
   printf("\nGot Ctrl-C. Terminating...\n");
   RFReceiver::closeAll();
+  exit(0);
 }
 #endif
 

--- a/build.sh
+++ b/build.sh
@@ -14,12 +14,12 @@ cp f007th-rpi ${BUILD_HOME}/bin/
 cd ${BUILD_HOME}/f007th-rpi_send
 make f007th-rpi_send
 status=$?
-if [ "$status" == 0 ]; then cp f007th-rpi_send ${BUILD_HOME}/bin/; fi
+if [ "$status" = 0 ]; then cp f007th-rpi_send ${BUILD_HOME}/bin/; fi
 
 cd ${BUILD_HOME}/f007th-ts-rpi
 make f007th-send
 status=$?
-if [ "$status" == 0 ]; then cp f007th-send ${BUILD_HOME}/bin/; fi
+if [ "$status" = 0 ]; then cp f007th-send ${BUILD_HOME}/bin/; fi
 cd ${BUILD_HOME}/bin
 
 exit $status

--- a/f007th-rpi_send/subdir.mk
+++ b/f007th-rpi_send/subdir.mk
@@ -4,14 +4,17 @@
 
 # Add inputs and outputs from these tool invocations to the build variables 
 CPP_SRCS += \
+../Logger.cpp \
 ../RFReceiver.cpp \
 ../f007th_send.cpp 
 
 OBJS += \
+./Logger.o \
 ./RFReceiver.o \
 ./f007th_send.o 
 
 CPP_DEPS += \
+./Logger.d \
 ./RFReceiver.d \
 ./f007th_send.d 
 


### PR DESCRIPTION
This is fantastic.  Thank you so much for putting it together.  I have the 00592TX and had found lots of discussion but no other code that came close.  This works great.

Here are a few fixes for few small issues I had while getting this running (on an RPi 3, compiling locally):
- add Logger to the build deps for f007th-rpi_send
- switche the status tests in `build.sh` to single-equals (bash is fine either way but sh doesn't like ==)
- add the `exit(0)` to actually exit on ctrl-C in non-gpio-ts mode