### PR TITLE
Update GPIO defaults

### DIFF
--- a/mach/rpi3.h
+++ b/mach/rpi3.h
@@ -39,8 +39,8 @@ gpio readall
 */
 
 #ifndef TEST_DECODING
-#define MAX_GPIO 53
-#define DEFAULT_PIN 27
+#define MAX_GPIO 1024 // is this correct? since kernel 6.6. the GPIO numbers are no longer 0 based so increase the MAX_GPIO
+#define DEFAULT_PIN 539 // GPIO27 is now PIN 539
 #endif
 
 #endif /* MACH_RPI3_H_ */


### PR DESCRIPTION
see https://github.com/alex-konshin/gpio-ts/pull/2 

since kernel 6.6 GPIO numbers are no longer 0 based, so increas MAX_GPIO and update DEFAULT_PIN